### PR TITLE
bug: improve reliability of network scripts

### DIFF
--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -75,9 +75,12 @@ class SymbolPeerClient:
         writer.write_int(0x111, 4)
         ssock.send(writer.buffer)
 
-    @staticmethod
-    def read_node_info_response(ssock):
+    def read_node_info_response(self, ssock):
         read_buffer = ssock.read()
+
+        if 0 == len(read_buffer):
+            raise ConnectionRefusedError('socket returned empty data for {}'.format(self.node_host))
+
         size = BufferReader(read_buffer).read_int(4)
 
         while len(read_buffer) < size:

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -83,11 +83,12 @@ class NodeDownloader:
                 is_reachable = True
 
                 json_peers = api_client.get_peers()
-            except (RequestException, TimeoutError, ConnectionRefusedError):
-                log.warning('failed to load peers from {}:{} (reachable node? {})'.format(
+            except (RequestException, TimeoutError, ConnectionRefusedError) as ex:
+                log.warning('failed to load peers from {}:{} (reachable node? {})\n{}'.format(
                     api_client.node_host,
                     api_client.node_port,
-                    is_reachable))
+                    is_reachable,
+                    ex))
                 json_peers = []
 
             with self.lock:


### PR DESCRIPTION
1. fail immediately if peer socket returns empty data

2. don't query `seed-only` nodes for (required) chain height