### PR TITLE
[network] task: added apiNodeStatus field

### DIFF
--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -4,6 +4,7 @@ from binascii import unhexlify
 from collections import namedtuple
 from pathlib import Path
 
+from requests.exceptions import RequestException
 from symbolchain.BufferReader import BufferReader
 from symbolchain.BufferWriter import BufferWriter
 from symbolchain.CryptoTypes import Hash256, PublicKey
@@ -204,7 +205,7 @@ class SymbolClient:
 			url = f'https://{self.node_host}:3001/node/info'
 			self.session.get(url, timeout=5)
 			return True
-		except:
+		except (RequestException, TimeoutError):
 			return False
 
 	def get_rest_version(self):
@@ -213,7 +214,7 @@ class SymbolClient:
 
 	def is_node_health(self):
 		json_response = self._get_json('node/health')
-		return all([json_response['status']['apiNode'] == 'up',  json_response['status']['db'] == 'up'])
+		return all([json_response['status']['apiNode'] == 'up', json_response['status']['db'] == 'up'])
 
 	@staticmethod
 	def _parse_account_info(json_account, mosaic_id=None):

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -200,19 +200,10 @@ class SymbolClient:
 
 		return account_infos
 
-	def is_https_valid(self):
+	def is_ssl(self):
 		try:
 			url = f'https://{self.node_host}:3001/node/info'
 			self.session.get(url, timeout=5)
-			return True
-		except:
-			return False
-
-	def is_wss_valid(self):
-		try:
-			url = f'wss://{self.node_host}:3001/ws'
-			ws = websocket.create_connection(url, timeout=5)
-			ws.close()
 			return True
 		except:
 			return False

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -3,7 +3,6 @@ import ssl
 from binascii import unhexlify
 from collections import namedtuple
 from pathlib import Path
-import websocket
 
 from symbolchain.BufferReader import BufferReader
 from symbolchain.BufferWriter import BufferWriter

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -3,6 +3,7 @@ import ssl
 from binascii import unhexlify
 from collections import namedtuple
 from pathlib import Path
+import websocket
 
 from symbolchain.BufferReader import BufferReader
 from symbolchain.BufferWriter import BufferWriter
@@ -198,6 +199,31 @@ class SymbolClient:
 			account_infos.append(self._parse_account_info(json_account_container['account'], mosaic_id))
 
 		return account_infos
+
+	def is_https_valid(self):
+		try:
+			url = f'https://{self.node_host}:3001/node/info'
+			self.session.get(url, timeout=5)
+			return True
+		except:
+			return False
+
+	def is_wss_valid(self):
+		try:
+			url = f'wss://{self.node_host}:3001/ws'
+			ws = websocket.create_connection(url, timeout=5)
+			ws.close()
+			return True
+		except:
+			return False
+
+	def get_rest_version(self):
+		json_response = self._get_json('node/server')
+		return json_response['serverInfo']['restVersion']
+
+	def is_node_health(self):
+		json_response = self._get_json('node/health')
+		return all([json_response['status']['apiNode'] == 'up',  json_response['status']['db'] == 'up'])
 
 	@staticmethod
 	def _parse_account_info(json_account, mosaic_id=None):

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -155,8 +155,7 @@ class NodeDownloader:
 			json_node['apiNodeInfo'] = {}
 			json_node['apiNodeInfo']['restVersion'] = api_client.get_rest_version()
 			json_node['apiNodeInfo']['isHealth'] = api_client.is_node_health()
-			json_node['apiNodeInfo']['isHttpsEnable'] = api_client.is_https_valid()
-			json_node['apiNodeInfo']['isWssEnable'] = api_client.is_wss_valid()
+			json_node['apiNodeInfo']['isSSL'] = api_client.is_ssl()
 
 	# this function must be called in context of self.lock
 	def _pop_next_api_client(self):

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -152,6 +152,11 @@ class NodeDownloader:
 
 		if not self.is_nem:
 			json_node['extraData']['finalizedHeight'] = api_client.get_finalization_info().height
+			json_node['apiNodeInfo'] = {}
+			json_node['apiNodeInfo']['restVersion'] = api_client.get_rest_version()
+			json_node['apiNodeInfo']['isHealth'] = api_client.is_node_health()
+			json_node['apiNodeInfo']['isHttpsEnable'] = api_client.is_https_valid()
+			json_node['apiNodeInfo']['isWssEnable'] = api_client.is_wss_valid()
 
 	# this function must be called in context of self.lock
 	def _pop_next_api_client(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ PyYAML==6.0.1
 requests==2.32.3
 symbol-sdk-python==3.2.0
 zenlog==1.1
+websocket==0.2.1
+websocket-client==1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ PyYAML==6.0.1
 requests==2.32.3
 symbol-sdk-python==3.2.0
 zenlog==1.1
-websocket==0.2.1
-websocket-client==1.5.1


### PR DESCRIPTION
## What was the issue?
- Add symbol node's apiNodeStatus field in symbolnodes.json files

## What's the fix?
- added a few methods in symbol client, 
- rest version, node health, and verify `ssl` status

Expected output:
```json
{
    "apiNodeInfo": {
      "isHealth": true,
      "isSSL": true,
      "restVersion": "2.4.2"
    },
    "extraData": {
         ...existing filed
    },
    ....existing field
  },
```