### PR TITLE
[account]: fixes and updates of account scripts

### DIFF
--- a/account/utils/SymbolAggregateBuilder.py
+++ b/account/utils/SymbolAggregateBuilder.py
@@ -1,9 +1,4 @@
-import sha3
-from symbolchain.CryptoTypes import Hash256
-from symbolchain.sc import Amount, Cosignature, PublicKey, Signature
-from symbolchain.symbol.Merkle import MerkleHashBuilder
-
-COSIGNATURE_SIZE = 104
+from symbolchain import sc
 
 
 class SymbolAggregateBuilder:
@@ -22,15 +17,18 @@ class SymbolAggregateBuilder:
 			**properties,
 			'type': 'aggregate_complete_transaction_v2',
 			'signer_public_key': self.signer_key_pair.public_key,
-			'transactions_hash': self._calculate_transactions_hash(),
 			'transactions': self.embedded_transactions
 		})
 
-		aggregate_transaction_size = aggregate_transaction.size + len(self.cosignatory_key_pairs) * COSIGNATURE_SIZE
-		aggregate_transaction.fee = Amount(aggregate_transaction_size * fee_multiplier)
+		aggregate_transaction_size = aggregate_transaction.size + len(self.cosignatory_key_pairs) * sc.Cosignature().size
+		aggregate_transaction.fee = sc.Amount(aggregate_transaction_size * fee_multiplier)
 		return aggregate_transaction
 
 	def sign(self, aggregate_transaction):
+		# some of the account scripts directly modify embedded transactions, so always recalculate the transactions_hash before signing
+		transactions_hash = self.facade.hash_embedded_transactions(aggregate_transaction.transactions)
+		aggregate_transaction.transactions_hash = sc.Hash256(transactions_hash.bytes)
+
 		# note: it's important to SIGN the transaction BEFORE adding cosignatures
 		signature = self.facade.sign_transaction(self.signer_key_pair, aggregate_transaction)
 		self.facade.transaction_factory.attach_signature(aggregate_transaction, signature)
@@ -38,18 +36,7 @@ class SymbolAggregateBuilder:
 		self._add_cosignatures(aggregate_transaction)
 		return signature
 
-	def _calculate_transactions_hash(self):
-		hash_builder = MerkleHashBuilder()
-		for embedded_transaction in self.embedded_transactions:
-			hash_builder.update(Hash256(sha3.sha3_256(embedded_transaction.serialize()).digest()))
-
-		return hash_builder.final()
-
 	def _add_cosignatures(self, aggregate_transaction):
-		aggregate_transaction_hash = self.facade.hash_transaction(aggregate_transaction).bytes
-		for key_pair in self.cosignatory_key_pairs:
-			cosignature = Cosignature()
-			cosignature.version = 0
-			cosignature.signer_public_key = PublicKey(key_pair.public_key.bytes)
-			cosignature.signature = Signature(key_pair.sign(aggregate_transaction_hash).bytes)
-			aggregate_transaction.cosignatures.append(cosignature)
+		aggregate_transaction.cosignatures.extend([
+			self.facade.cosign_transaction(key_pair, aggregate_transaction) for key_pair in self.cosignatory_key_pairs
+		])

--- a/account/utils/facade_utils.py
+++ b/account/utils/facade_utils.py
@@ -17,7 +17,7 @@ def create_blockchain_facade(blockchain_descriptor):
 
 
 def save_transaction(facade, transaction, signature, output_directory, name):
-	facade.transaction_factory.attach_signature(transaction, signature)
+	json_payload = facade.transaction_factory.attach_signature(transaction, signature)
 
 	log.info(f'*** {name} ***')
 	log.debug(transaction)
@@ -28,8 +28,8 @@ def save_transaction(facade, transaction, signature, output_directory, name):
 	output_filepath = Path(output_directory) / f'{name}.dat'
 	log.info(f'saving "{name}" to "{output_filepath}"')
 
-	with open(output_filepath, 'wb') as outfile:
-		outfile.write(transaction.serialize())
+	with open(output_filepath, 'wt', encoding='utf8') as outfile:
+		outfile.write(json_payload)
 
 
 def main_loop(args, preparer_class, property_name):


### PR DESCRIPTION
    [account]: update save_transaction to save transaction as JSON
    
     problem: transaction is being saved as binary, which cannot be sent directly to Symbol REST
    solution: save as JSON, which is compatible with both NEM and Symbol

    [account]: fix and update SymbolAggregateBuilder
    
     problem: some of the account scripts modify embedded transactions prior to signing and corrupt transactions_hash
    solution: calculate transactions_hash directly before signing in SymbolAggregateBuilder
    
     problem: some of the functionality in SymbolAggregateBuilder is built into SymbolFacade now
    solution: use SymbolFacade implementations as appropriate
