### PR TITLE
[history]: fixes and updates of history scripts

### DIFF
--- a/history/downloader.py
+++ b/history/downloader.py
@@ -30,6 +30,8 @@ class ChainActivityDownloader:
 		if not num_rows_written:
 			Path(output_filepath).unlink()
 
+		log.debug(f'[{output_filepath}] download complete!')
+
 	def _download_batch(self, mode, start_date, end_date, output_filepath, csv_writer):
 		# pylint: disable=too-many-arguments
 

--- a/history/summarizer.py
+++ b/history/summarizer.py
@@ -71,7 +71,7 @@ class Loader():
 			csv_writer = csv.DictWriter(outfile, field_names)
 			csv_writer.writerow(dict(zip(field_names, field_names)))
 
-			for row in sorted(self.rows, key=lambda row: row['date']):
+			for row in sorted(self.rows, key=lambda row: (row['date'] is not None, row['date'])):
 				csv_writer.writerow(row)
 
 


### PR DESCRIPTION
    [history]: add log when file download is complete
    
     problem: it is difficult to track completion with multiple files being downloaded in parallel
    solution: add long when each file is downloaded completely

    [history]: summarizer fails when there are no records for period
    
     problem: date is only calculated when there are matching records for period
              when there are no matching records, there is no date and sorting fails
    solution: check if date exists before accessing during sort
