### PR TITLE
[network]: Added node tracker to collect node count from network

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,23 @@ Example: The script can take an input file named `symbolnodes.json`, which conta
 ```sh
 python3 -m network.geolocation --file ./symbolnodes.json --output geolocation.json
 ```
+
+### nodeTracker
+
+_capture and generates number of nodes in a network_
+
+snapshot number of nodes in a network and store it as time series data into `./network_node_history` folder.
+
+Example: The script can take an input file named `symbol_nodes.json`, calculate node by roles and store the data as time series data into `./network_node_history` folder.
+
+```sh
+python3 -m network.nodeTracker --action capture --input ./symbol_nodes.json
+```
+
+Generate daily node count snapshot result and append it to `node_counts_symbol.json`.
+
+Example: The script filter snapshot file by date from `./network_node_history` folder and generate daily node count snapshot result.
+
+```sh
+python3 -m network.nodeTracker --action generate --snapshot-date 20250320 --output node_counts_symbol.json
+```

--- a/README.md
+++ b/README.md
@@ -205,20 +205,12 @@ python3 -m network.geolocation --file ./symbolnodes.json --output geolocation.js
 
 ### nodeTracker
 
-_capture and generates number of nodes in a network_
+_capture number of nodes in a network_
 
-snapshot number of nodes in a network and store it as time series data into `./network_node_history` folder.
+snapshot number of nodes in a network and append it to a time series file.
 
-Example: The script can take an input file named `symbol_nodes.json`, calculate node by roles and store the data as time series data into `./network_node_history` folder.
-
-```sh
-python3 -m network.nodeTracker --action capture --input ./symbol_nodes.json
-```
-
-Generate daily node count snapshot result and append it to `node_counts_symbol.json`.
-
-Example: The script filter snapshot file by date from `./network_node_history` folder and generate daily node count snapshot result.
+Example: The script can take an input file named `symbol_nodes.json`, calculate node by roles and append the result to output file named `node_counts_symbol.json`.
 
 ```sh
-python3 -m network.nodeTracker --action generate --snapshot-date 20250320 --output node_counts_symbol.json
+python3 -m network.nodeTracker --input ./symbol_nodes.json --output node_counts_symbol.json
 ```

--- a/network/nodeTracker.py
+++ b/network/nodeTracker.py
@@ -11,87 +11,6 @@ class NodeTracker:
 	Class for tracking the number of nodes in a network.
 	"""
 
-	def __init__(self, history_directory):
-		self.history_directory = history_directory
-
-		if not os.path.exists(self.history_directory):
-			os.makedirs(self.history_directory)
-			log.info(f'Created history directory: {self.history_directory}')
-
-	def capture_snapshot(self, nodes_file):
-		"""
-		Captures a snapshot of the current number of nodes in the network.
-		"""
-
-		try:
-			with open(nodes_file, 'r', encoding='utf8') as infile:
-				nodes = json.load(infile)
-		except Exception as ex:
-			raise ValueError(f'Error reading input file: {str(ex)}') from ex
-
-		roles = {}
-		for node in nodes:
-			role = node['roles']
-			if role in roles:
-				roles[role] += 1
-			else:
-				roles[role] = 1
-
-		timestamp = datetime.utcnow()
-		snapshot_file = os.path.join(self.history_directory, f'nodes_snapshot_{timestamp}.json')
-
-		with open(snapshot_file, 'w', encoding='utf8') as outfile:
-			json.dump(roles, outfile, indent=4, sort_keys=True)
-
-		log.info(f'Captured node snapshot with {len(nodes)} nodes: {snapshot_file}')
-
-	def _get_snapshot_files(self, file_date=None):
-		"""
-		Returns a list of snapshot files in the history directory.
-		"""
-
-		snapshot_files = [f for f in os.listdir(self.history_directory) if f.startswith('nodes_snapshot_')]
-		filtered_files = []
-
-		for snapshot_file in snapshot_files:
-			timestamp_file = snapshot_file.replace('nodes_snapshot_', '').replace('.json', '')
-			timestamp = datetime.strptime(timestamp_file, '%Y-%m-%d %H:%M:%S.%f').date()
-
-			if file_date and timestamp < datetime.strptime(file_date, '%Y%m%d').date():
-				continue
-
-			if file_date and timestamp > datetime.strptime(file_date, '%Y%m%d').date():
-				continue
-
-			filtered_files.append(snapshot_file)
-
-		return filtered_files
-
-	def _calculate_average_counts(self, snapshots):  # pylint: disable=no-self-use
-		"""
-		Calculates the average number of nodes in the snapshots.
-		"""
-
-		average_counts = {}
-		for snapshot in snapshots:
-			node_roles = ['1', '2', '3', '4', '5', '6', '7']
-
-			# Count nodes for each role
-			for node_role in node_roles:
-				if node_role not in average_counts:
-					average_counts[node_role] = 0
-
-				if node_role in snapshot:
-					average_counts[node_role] += snapshot[node_role]
-
-		# Calculate averages
-		for node_role in average_counts:
-			average_counts[node_role] = round(average_counts[node_role] / len(snapshots))
-
-		# Add total
-		average_counts['total'] = sum(average_counts.values())
-		return average_counts
-
 	def _load_time_series_data(self, output):  # pylint: disable=no-self-use
 		"""
 		Loads the time series data from the output file.
@@ -107,81 +26,77 @@ class NodeTracker:
 
 		return time_series_data
 
-	def _save_time_series_data(self, time_series_data, output):  # pylint: disable=no-self-use
+	def _add_data_point(self, data_point, output_file):  # pylint: disable=no-self-use
 		"""
-		Saves the time series data to the output file.
+		Adds a new data point to the time series data.
 		"""
 
-		with open(output, 'w', encoding='utf8') as outfile:
-			json.dump(time_series_data, outfile, indent=4, sort_keys=True)
+		# Load existing time series data
+		time_series = self._load_time_series_data(output_file)
 
-		log.info(f'Saved time series data to: {output}')
+		# Check if snapshot already exists
+		existing_dates = {entry['date'] for entry in time_series}
+		if data_point['date'] in existing_dates:
+			raise ValueError(f'Time series data for {data_point["date"]} already exists')
 
-	def generate_time_series(self, output=None, snapshot_date=None):
+		time_series.append(data_point)
+
+		with open(output_file, 'w', encoding='utf8') as outfile:
+			json.dump(time_series, outfile, indent=4, sort_keys=True)
+
+		log.info(f'Saved time series data to: {output_file}')
+
+	def _count_roles(self, nodes):  # pylint: disable=no-self-use
+		"""
+		Counts the number of nodes for each role.
+		"""
+
+		node_roles = ['1', '2', '3', '4', '5', '6', '7']
+
+		roles = {}
+		for role in node_roles:
+			roles[role] = 0
+
+		for node in nodes:
+			role = str(node['roles'])
+			if role in node_roles:
+				roles[role] += 1
+
+		roles['total'] = sum(roles.values())
+
+		return roles
+
+	def generate_time_series(self, input_file, output_file):
 		"""
 		Generates a time series data file from the node snapshots.
 		"""
 
-		# Get snapshot files by date range
-		snapshot_files = self._get_snapshot_files(snapshot_date)
+		try:
+			with open(input_file, 'r', encoding='utf8') as infile:
+				nodes = json.load(infile)
+		except Exception as ex:
+			raise ValueError(f'Error reading input file: {str(ex)}') from ex
 
-		# Load snapshots data
-		snapshots = []
-		for snapshot_file in snapshot_files:
-			with open(os.path.join(self.history_directory, snapshot_file), 'r', encoding='utf8') as infile:
-				snapshot = json.load(infile)
-				snapshots.append(snapshot)
-
-		if not snapshots:
-			raise ValueError('No snapshots found')
-
-		# Calculate average counts
-		average_counts = self._calculate_average_counts(snapshots)
-
-		# Load existing time series data from output file
-		time_series_data = self._load_time_series_data(output)
+		roles = self._count_roles(nodes)
 
 		new_snapshot = {
-			'date': datetime.strptime(snapshot_date, '%Y%m%d').strftime('%Y-%m-%d'),
-			'values': average_counts
+			'date': datetime.utcnow().strftime('%Y-%m-%d'),
+			'values': roles
 		}
 
-		# Check if snapshot already exists
-		existing_dates = {entry['date'] for entry in time_series_data}
-		if new_snapshot['date'] in existing_dates:
-			raise ValueError(f'Time series data for {snapshot_date} already exists')
-
-		time_series_data.append(new_snapshot)
-
 		# Save time series data
-		self._save_time_series_data(time_series_data, output)
+		self._add_data_point(new_snapshot, output_file)
 
 
 def main():
 	parser = argparse.ArgumentParser(description='Track and analyze node count over time')
-	parser.add_argument('--action', choices=('capture', 'generate'), required=True, help='capture a new snapshot or generate data')
-	parser.add_argument('--input', help='nodes json file', required=False)
-	parser.add_argument('--history-directory', default='./network_node_history', help='Directory to store node history snapshots')
-	parser.add_argument('--output', help='Output file for time series data', required=False)
-	parser.add_argument('--snapshot-date', help='snapshot date for analysis (YYYYMMDD)', required=False)
+	parser.add_argument('--input', help='nodes json file', required=True)
+	parser.add_argument('--output', help='Output file for time series data', required=True)
 
 	args = parser.parse_args()
 
-	node_tracker = NodeTracker(args.history_directory)
-
-	if 'capture' == args.action:
-		if not args.input:
-			raise ValueError('--input is required for capture action')
-
-		node_tracker.capture_snapshot(args.input)
-	elif 'generate' == args.action:
-		if not args.output:
-			raise ValueError('--output is required for generate action')
-
-		if not args.snapshot_date:
-			raise ValueError('--snapshot-date is required for generate action')
-
-		node_tracker.generate_time_series(args.output, args.snapshot_date)
+	node_tracker = NodeTracker()
+	node_tracker.generate_time_series(args.input, args.output)
 
 
 if '__main__' == __name__:

--- a/network/nodeTracker.py
+++ b/network/nodeTracker.py
@@ -11,7 +11,8 @@ class NodeTracker:
 	Class for tracking the number of nodes in a network.
 	"""
 
-	def _load_time_series_data(self, output):  # pylint: disable=no-self-use
+	@staticmethod
+	def _load_time_series_data(output):
 		"""
 		Loads the time series data from the output file.
 		"""
@@ -35,8 +36,7 @@ class NodeTracker:
 		time_series = self._load_time_series_data(output_file)
 
 		# Check if snapshot already exists
-		existing_dates = {entry['date'] for entry in time_series}
-		if data_point['date'] in existing_dates:
+		if time_series and time_series[-1]['date'] == data_point['date']:
 			raise ValueError(f'Time series data for {data_point["date"]} already exists')
 
 		time_series.append(data_point)
@@ -61,6 +61,8 @@ class NodeTracker:
 			role = str(node['roles'])
 			if role in node_roles:
 				roles[role] += 1
+			else:
+				log.warning(f'Unknown node role: {role}')
 
 		roles['total'] = sum(roles.values())
 

--- a/network/nodeTracker.py
+++ b/network/nodeTracker.py
@@ -46,7 +46,8 @@ class NodeTracker:
 
 		log.info(f'Saved time series data to: {output_file}')
 
-	def _count_roles(self, nodes):  # pylint: disable=no-self-use
+	@staticmethod
+	def _count_roles(nodes):
 		"""
 		Counts the number of nodes for each role.
 		"""

--- a/network/nodeTracker.py
+++ b/network/nodeTracker.py
@@ -27,7 +27,7 @@ class NodeTracker:
 
 		return time_series_data
 
-	def _add_data_point(self, data_point, output_file):  # pylint: disable=no-self-use
+	def _add_data_point(self, data_point, output_file):
 		"""
 		Adds a new data point to the time series data.
 		"""

--- a/network/nodeTracker.py
+++ b/network/nodeTracker.py
@@ -141,10 +141,17 @@ class NodeTracker:
 		# Load existing time series data from output file
 		time_series_data = self._load_time_series_data(output)
 
-		time_series_data.append({
-			'date': str(datetime.utcnow()),
+		new_snapshot = {
+			'date': datetime.strptime(snapshot_date, '%Y%m%d').strftime('%Y-%m-%d'),
 			'values': average_counts
-		})
+		}
+
+		# Check if snapshot already exists
+		existing_dates = {entry['date'] for entry in time_series_data}
+		if new_snapshot['date'] in existing_dates:
+			raise ValueError(f'Time series data for {snapshot_date} already exists')
+
+		time_series_data.append(new_snapshot)
 
 		# Save time series data
 		self._save_time_series_data(time_series_data, output)

--- a/network/nodeTracker.py
+++ b/network/nodeTracker.py
@@ -1,0 +1,181 @@
+import argparse
+import json
+import os
+from datetime import datetime
+
+from zenlog import log
+
+
+class NodeTracker:
+	"""
+	Class for tracking the number of nodes in a network.
+	"""
+
+	def __init__(self, history_directory):
+		self.history_directory = history_directory
+
+		if not os.path.exists(self.history_directory):
+			os.makedirs(self.history_directory)
+			log.info(f'Created history directory: {self.history_directory}')
+
+	def capture_snapshot(self, nodes_file):
+		"""
+		Captures a snapshot of the current number of nodes in the network.
+		"""
+
+		try:
+			with open(nodes_file, 'r', encoding='utf8') as infile:
+				nodes = json.load(infile)
+		except Exception as ex:
+			raise ValueError(f'Error reading input file: {str(ex)}') from ex
+
+		roles = {}
+		for node in nodes:
+			role = node['roles']
+			if role in roles:
+				roles[role] += 1
+			else:
+				roles[role] = 1
+
+		timestamp = datetime.utcnow()
+		snapshot_file = os.path.join(self.history_directory, f'nodes_snapshot_{timestamp}.json')
+
+		with open(snapshot_file, 'w', encoding='utf8') as outfile:
+			json.dump(roles, outfile, indent=4, sort_keys=True)
+
+		log.info(f'Captured node snapshot with {len(nodes)} nodes: {snapshot_file}')
+
+	def _get_snapshot_files(self, file_date=None):
+		"""
+		Returns a list of snapshot files in the history directory.
+		"""
+
+		snapshot_files = [f for f in os.listdir(self.history_directory) if f.startswith('nodes_snapshot_')]
+		filtered_files = []
+
+		for snapshot_file in snapshot_files:
+			timestamp_file = snapshot_file.replace('nodes_snapshot_', '').replace('.json', '')
+			timestamp = datetime.strptime(timestamp_file, '%Y-%m-%d %H:%M:%S.%f').date()
+
+			if file_date and timestamp < datetime.strptime(file_date, '%Y%m%d').date():
+				continue
+
+			if file_date and timestamp > datetime.strptime(file_date, '%Y%m%d').date():
+				continue
+
+			filtered_files.append(snapshot_file)
+
+		return filtered_files
+
+	def _calculate_average_counts(self, snapshots):  # pylint: disable=no-self-use
+		"""
+		Calculates the average number of nodes in the snapshots.
+		"""
+
+		average_counts = {}
+		for snapshot in snapshots:
+			node_roles = ['1', '2', '3', '4', '5', '6', '7']
+
+			# Count nodes for each role
+			for node_role in node_roles:
+				if node_role not in average_counts:
+					average_counts[node_role] = 0
+
+				if node_role in snapshot:
+					average_counts[node_role] += snapshot[node_role]
+
+		# Calculate averages
+		for node_role in average_counts:
+			average_counts[node_role] = round(average_counts[node_role] / len(snapshots))
+
+		# Add total
+		average_counts['total'] = sum(average_counts.values())
+		return average_counts
+
+	def _load_time_series_data(self, output):  # pylint: disable=no-self-use
+		"""
+		Loads the time series data from the output file.
+		"""
+
+		time_series_data = []
+		if os.path.exists(output) and os.path.getsize(output) > 0:
+			try:
+				with open(output, 'r', encoding='utf8') as infile:
+					time_series_data = json.load(infile)
+			except Exception as ex:
+				raise ValueError(f'Error reading input file: {str(ex)}') from ex
+
+		return time_series_data
+
+	def _save_time_series_data(self, time_series_data, output):  # pylint: disable=no-self-use
+		"""
+		Saves the time series data to the output file.
+		"""
+
+		with open(output, 'w', encoding='utf8') as outfile:
+			json.dump(time_series_data, outfile, indent=4, sort_keys=True)
+
+		log.info(f'Saved time series data to: {output}')
+
+	def generate_time_series(self, output=None, snapshot_date=None):
+		"""
+		Generates a time series data file from the node snapshots.
+		"""
+
+		# Get snapshot files by date range
+		snapshot_files = self._get_snapshot_files(snapshot_date)
+
+		# Load snapshots data
+		snapshots = []
+		for snapshot_file in snapshot_files:
+			with open(os.path.join(self.history_directory, snapshot_file), 'r', encoding='utf8') as infile:
+				snapshot = json.load(infile)
+				snapshots.append(snapshot)
+
+		if not snapshots:
+			raise ValueError('No snapshots found')
+
+		# Calculate average counts
+		average_counts = self._calculate_average_counts(snapshots)
+
+		# Load existing time series data from output file
+		time_series_data = self._load_time_series_data(output)
+
+		time_series_data.append({
+			'date': str(datetime.utcnow()),
+			'values': average_counts
+		})
+
+		# Save time series data
+		self._save_time_series_data(time_series_data, output)
+
+
+def main():
+	parser = argparse.ArgumentParser(description='Track and analyze node count over time')
+	parser.add_argument('--action', choices=('capture', 'generate'), required=True, help='capture a new snapshot or generate data')
+	parser.add_argument('--input', help='nodes json file', required=False)
+	parser.add_argument('--history-directory', default='./network_node_history', help='Directory to store node history snapshots')
+	parser.add_argument('--output', help='Output file for time series data', required=False)
+	parser.add_argument('--snapshot-date', help='snapshot date for analysis (YYYYMMDD)', required=False)
+
+	args = parser.parse_args()
+
+	node_tracker = NodeTracker(args.history_directory)
+
+	if 'capture' == args.action:
+		if not args.input:
+			raise ValueError('--input is required for capture action')
+
+		node_tracker.capture_snapshot(args.input)
+	elif 'generate' == args.action:
+		if not args.output:
+			raise ValueError('--output is required for generate action')
+
+		if not args.snapshot_date:
+			raise ValueError('--snapshot-date is required for generate action')
+
+		node_tracker.generate_time_series(args.output, args.snapshot_date)
+
+
+if '__main__' == __name__:
+	main()


### PR DESCRIPTION
Problem: The node count from the network is missing.
Solution: An added node tracker can capture and generate time series node count results from the network.

Sample output:

```json
[
    {
        "date": "2025-03-20",
        "values": {
            "1": 1,
            "2": 0,
            "3": 98,
            "4": 0,
            "5": 2,
            "6": 0,
            "7": 34,
            "total": 135
        }
    },
    {
        "date": "2025-03-21",
        "values": {
            "1": 1,
            "2": 0,
            "3": 98,
            "4": 0,
            "5": 2,
            "6": 0,
            "7": 34,
            "total": 135
        }
    }
]
```