### PR TITLE
[network]: fix object has no attribute error

### DIFF
--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -219,6 +219,12 @@ class SymbolClient(SymbolLightClient):
 	@staticmethod
 	def from_node_info_dict(dict_node_info, **kwargs):
 		if not dict_node_info['roles'] & 2:
+			light_client = SymbolLightClient(dict_node_info['host'], **kwargs)
+			rest_version = light_client.get_rest_version()
+
+			if rest_version:
+				return light_client
+
 			return SymbolPeerClient(dict_node_info['host'], dict_node_info['port'], **kwargs)
 
 		return SymbolClient(dict_node_info['host'], **kwargs)

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -54,14 +54,35 @@ class AccountInfo:
 		self.voting_public_keys = []
 
 
-class SymbolLightRESTClient:
+class SymbolLightClient:
 	"""
 	Class for Symbol light rest client.
 	"""
 
-	def __init__(self, host, **kwargs):
+	def __init__(self, host, port=3000, **kwargs):
 		self.node_host = host
+		self.node_port = port
 		self.session = create_http_session(**kwargs)
+
+	def get_chain_height(self):
+		json_response = self._get_json('chain/info')
+		return int(json_response['height'])
+
+	def get_finalization_info(self):
+		json_response = self._get_json('chain/info')
+		json_finalization_info = json_response['latestFinalizedBlock']
+		return FinalizationInfo(
+			int(json_finalization_info['finalizationEpoch']),
+			int(json_finalization_info['finalizationPoint']),
+			int(json_finalization_info['height']))
+
+	def get_node_info(self):
+		json_response = self._get_json('node/info')
+		return json_response
+
+	def get_peers(self):
+		json_response = self._get_json('node/peers')
+		return json_response
 
 	def is_ssl(self):
 		try:
@@ -73,17 +94,18 @@ class SymbolLightRESTClient:
 
 	def get_rest_version(self):
 		try:
-			json_http_headers = {'Content-type': 'application/json'}
-			json_response = self.session.get(f'http://{self.node_host}:3000/node/server', headers=json_http_headers).json()
-
+			json_response = self._get_json('node/server')
 			return json_response['serverInfo']['restVersion']
 		except (RequestException, TimeoutError):
 			return None
 
+	def _get_json(self, rest_path):
+		json_http_headers = {'Content-type': 'application/json'}
+		return self.session.get(f'http://{self.node_host}:{self.node_port}/{rest_path}', headers=json_http_headers).json()
 
-class SymbolPeerClient(SymbolLightRESTClient):
+
+class SymbolPeerClient():
 	def __init__(self, host, port=7890, **kwargs):
-		super().__init__(host, **kwargs)
 		(self.node_host, self.node_port) = (host, port)
 		self.certificate_directory = Path(kwargs.get('certificate_directory'))
 		self.timeout = kwargs.get('timeout', 10)
@@ -173,14 +195,24 @@ class SymbolPeerClient(SymbolLightRESTClient):
 		return node_info
 
 	@staticmethod
+	def get_rest_version():
+		# Peer node does not have this method
+		return None
+
+	@staticmethod
+	def is_ssl():
+		# Peer node does not have this method
+		return None
+
+	@staticmethod
 	def is_node_health():
-		# Light node does not have this method
+		# Peer node does not have this method
 		return None
 
 
-class SymbolClient(SymbolLightRESTClient):
+class SymbolClient(SymbolLightClient):
 	def __init__(self, host, port=3000, **kwargs):
-		super().__init__(host, **kwargs)
+		super().__init__(host, port, **kwargs)
 		(self.node_host, self.node_port) = (host, port)
 		self.network = Network.MAINNET
 
@@ -191,29 +223,9 @@ class SymbolClient(SymbolLightRESTClient):
 
 		return SymbolClient(dict_node_info['host'], **kwargs)
 
-	def get_chain_height(self):
-		json_response = self._get_json('chain/info')
-		return int(json_response['height'])
-
-	def get_finalization_info(self):
-		json_response = self._get_json('chain/info')
-		json_finalization_info = json_response['latestFinalizedBlock']
-		return FinalizationInfo(
-			int(json_finalization_info['finalizationEpoch']),
-			int(json_finalization_info['finalizationPoint']),
-			int(json_finalization_info['height']))
-
 	def get_harvester_signer_public_key(self, height):
 		json_response = self._get_json(f'blocks/{height}')
 		return PublicKey(json_response['block']['signerPublicKey'])
-
-	def get_node_info(self):
-		json_response = self._get_json('node/info')
-		return json_response
-
-	def get_peers(self):
-		json_response = self._get_json('node/peers')
-		return json_response
 
 	def get_account_info(self, address, mosaic_id=None):
 		json_response = self._get_json(f'accounts/{address}')
@@ -394,7 +406,3 @@ class SymbolClient(SymbolLightRESTClient):
 
 	def _get_page(self, rest_path, start_id):
 		return self._get_json(rest_path if not start_id else f'{rest_path}&offset={start_id}')
-
-	def _get_json(self, rest_path):
-		json_http_headers = {'Content-type': 'application/json'}
-		return self.session.get(f'http://{self.node_host}:{self.node_port}/{rest_path}', headers=json_http_headers).json()

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -54,8 +54,36 @@ class AccountInfo:
 		self.voting_public_keys = []
 
 
-class SymbolPeerClient:
+class SymbolLightRESTClient:
+	"""
+	Class for Symbol light rest client.
+	"""
+
+	def __init__(self, host, **kwargs):
+		self.node_host = host
+		self.session = create_http_session(**kwargs)
+
+	def is_ssl(self):
+		try:
+			url = f'https://{self.node_host}:3001/node/info'
+			self.session.get(url, timeout=5)
+			return True
+		except (RequestException, TimeoutError):
+			return False
+
+	def get_rest_version(self):
+		try:
+			json_http_headers = {'Content-type': 'application/json'}
+			json_response = self.session.get(f'http://{self.node_host}:3000/node/server', headers=json_http_headers).json()
+
+			return json_response['serverInfo']['restVersion']
+		except (RequestException, TimeoutError):
+			return None
+
+
+class SymbolPeerClient(SymbolLightRESTClient):
 	def __init__(self, host, port=7890, **kwargs):
+		super().__init__(host, **kwargs)
 		(self.node_host, self.node_port) = (host, port)
 		self.certificate_directory = Path(kwargs.get('certificate_directory'))
 		self.timeout = kwargs.get('timeout', 10)
@@ -144,10 +172,15 @@ class SymbolPeerClient:
 
 		return node_info
 
+	@staticmethod
+	def is_node_health():
+		# Light node does not have this method
+		return None
 
-class SymbolClient:
+
+class SymbolClient(SymbolLightRESTClient):
 	def __init__(self, host, port=3000, **kwargs):
-		self.session = create_http_session(**kwargs)
+		super().__init__(host, **kwargs)
 		(self.node_host, self.node_port) = (host, port)
 		self.network = Network.MAINNET
 
@@ -199,18 +232,6 @@ class SymbolClient:
 			account_infos.append(self._parse_account_info(json_account_container['account'], mosaic_id))
 
 		return account_infos
-
-	def is_ssl(self):
-		try:
-			url = f'https://{self.node_host}:3001/node/info'
-			self.session.get(url, timeout=5)
-			return True
-		except (RequestException, TimeoutError):
-			return False
-
-	def get_rest_version(self):
-		json_response = self._get_json('node/server')
-		return json_response['serverInfo']['restVersion']
 
 	def is_node_health(self):
 		json_response = self._get_json('node/health')

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -99,6 +99,10 @@ class SymbolLightClient:
 		except (RequestException, TimeoutError):
 			return None
 
+	def is_node_health(self):  # pylint: disable=no-self-use
+		# Light node does not have this method
+		return None
+
 	def _get_json(self, rest_path):
 		json_http_headers = {'Content-type': 'application/json'}
 		return self.session.get(f'http://{self.node_host}:{self.node_port}/{rest_path}', headers=json_http_headers).json()

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -63,6 +63,7 @@ class SymbolLightClient:
 		self.node_host = host
 		self.node_port = port
 		self.session = create_http_session(**kwargs)
+		self.timeout = kwargs.get('timeout', 5)
 
 	def get_chain_height(self):
 		json_response = self._get_json('chain/info')
@@ -87,7 +88,7 @@ class SymbolLightClient:
 	def is_ssl(self):
 		try:
 			url = f'https://{self.node_host}:3001/node/info'
-			self.session.get(url, timeout=5)
+			self.session.get(url, timeout=self.timeout)
 			return True
 		except (RequestException, TimeoutError):
 			return False

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -14,7 +14,7 @@ from zenlog import log
 from .pod import TransactionSnapshot
 from .TimeoutHTTPAdapter import create_http_session
 
-FinalizationInfo = namedtuple('FinalizationInfo', ['epoch', 'point', 'height'])
+FinalizationInfo = namedtuple('FinalizationInfo', ['epoch', 'point', 'height', 'hash'])
 VotingPublicKey = namedtuple('VotingPublicKey', ['start_epoch', 'end_epoch', 'public_key'])
 
 
@@ -75,7 +75,8 @@ class SymbolLightClient:
 		return FinalizationInfo(
 			int(json_finalization_info['finalizationEpoch']),
 			int(json_finalization_info['finalizationPoint']),
-			int(json_finalization_info['height']))
+			int(json_finalization_info['height']),
+			str(json_finalization_info['hash']))
 
 	def get_node_info(self):
 		json_response = self._get_json('node/info')
@@ -126,8 +127,9 @@ class SymbolPeerClient():
 		return self._send_socket_request(5, self._parse_chain_statistics_response)['height']
 
 	def get_finalization_info(self):
-		# epoch and point are zeroed for now
-		return FinalizationInfo(0, 0, self._send_socket_request(5, self._parse_chain_statistics_response)['finalizedHeight'])
+		finalization_info = self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)
+
+		return FinalizationInfo(**finalization_info)
 
 	def get_node_info(self):
 		return self._send_socket_request(0x111, self._parse_node_info_response)
@@ -198,6 +200,17 @@ class SymbolPeerClient():
 		node_info['friendlyName'] = reader.read_bytes(name_size).decode('utf8')
 
 		return node_info
+
+	@staticmethod
+	def _parse_node_finalization_statistics_response(reader):
+		finalization_statistics = {}
+
+		finalization_statistics['epoch'] = reader.read_int(4)
+		finalization_statistics['point'] = reader.read_int(4)
+		finalization_statistics['height'] = reader.read_int(8)
+		finalization_statistics['hash'] = str(Hash256(reader.read_bytes(32)))
+
+		return finalization_statistics
 
 
 class SymbolClient(SymbolLightClient):

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -199,21 +199,6 @@ class SymbolPeerClient():
 
 		return node_info
 
-	@staticmethod
-	def get_rest_version():
-		# Peer node does not have this method
-		return None
-
-	@staticmethod
-	def is_ssl():
-		# Peer node does not have this method
-		return None
-
-	@staticmethod
-	def is_node_health():
-		# Peer node does not have this method
-		return None
-
 
 class SymbolClient(SymbolLightClient):
 	def __init__(self, host, port=3000, **kwargs):

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -179,14 +179,16 @@ class NodeDownloader:
 	def _update(self, public_key, json_node, json_peers):
 		self.public_key_to_node_info_map[public_key] = json_node
 		for json_peer in json_peers:
-			peer_api_client = self.api_client_class.from_node_info_dict(
-				json_peer,
-				retry_count=2,
-				timeout=self.timeout,
-				certificate_directory=self.certificate_directory)
+			host = json_peer.get('host')
 
-			if peer_api_client and peer_api_client.node_host not in self.visited_hosts:
-				if not any(peer_api_client.node_host == api_client.node_host for api_client in self.remaining_api_clients):
+			if host not in self.visited_hosts:
+				if not any(host == api_client.node_host for api_client in self.remaining_api_clients):
+					peer_api_client = self.api_client_class.from_node_info_dict(
+						json_peer,
+						retry_count=2,
+						timeout=self.timeout,
+						certificate_directory=self.certificate_directory)
+
 					self.remaining_api_clients.append(peer_api_client)
 
 	def save(self, output_filepath):

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -153,10 +153,11 @@ class NodeDownloader:
 		if not self.is_nem:
 			json_node['extraData']['finalizedHeight'] = api_client.get_finalization_info().height
 
-			json_node['apiNodeInfo'] = {}
-			json_node['apiNodeInfo']['restVersion'] = api_client.get_rest_version()
-			json_node['apiNodeInfo']['isSSL'] = api_client.is_ssl()
-			json_node['apiNodeInfo']['isHealth'] = api_client.is_node_health()
+			if hasattr(api_client, 'get_rest_version'):
+				json_node['apiNodeInfo'] = {}
+				json_node['apiNodeInfo']['restVersion'] = api_client.get_rest_version()
+				json_node['apiNodeInfo']['isSSL'] = api_client.is_ssl()
+				json_node['apiNodeInfo']['isHealth'] = api_client.is_node_health()
 
 	# this function must be called in context of self.lock
 	def _pop_next_api_client(self):

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -152,10 +152,13 @@ class NodeDownloader:
 
 		if not self.is_nem:
 			json_node['extraData']['finalizedHeight'] = api_client.get_finalization_info().height
-			json_node['apiNodeInfo'] = {}
-			json_node['apiNodeInfo']['restVersion'] = api_client.get_rest_version()
-			json_node['apiNodeInfo']['isHealth'] = api_client.is_node_health()
-			json_node['apiNodeInfo']['isSSL'] = api_client.is_ssl()
+
+			# only add apiNodeInfo if only api node
+			if json_node['roles'] & 2:
+				json_node['apiNodeInfo'] = {}
+				json_node['apiNodeInfo']['restVersion'] = api_client.get_rest_version()
+				json_node['apiNodeInfo']['isHealth'] = api_client.is_node_health()
+				json_node['apiNodeInfo']['isSSL'] = api_client.is_ssl()
 
 	# this function must be called in context of self.lock
 	def _pop_next_api_client(self):

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -153,7 +153,7 @@ class NodeDownloader:
 		if not self.is_nem:
 			json_node['extraData']['finalizedHeight'] = api_client.get_finalization_info().height
 
-			# only add apiNodeInfo if only api node
+			# add apiNodeInfo if API node roles are included
 			if json_node['roles'] & 2:
 				json_node['apiNodeInfo'] = {}
 				json_node['apiNodeInfo']['restVersion'] = api_client.get_rest_version()

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -151,7 +151,11 @@ class NodeDownloader:
 		json_node['extraData']['height'] = api_client.get_chain_height()
 
 		if not self.is_nem:
-			json_node['extraData']['finalizedHeight'] = api_client.get_finalization_info().height
+			finalization_info = api_client.get_finalization_info()
+			json_node['extraData']['finalizedHeight'] = finalization_info.height
+			json_node['extraData']['finalizedEpoch'] = finalization_info.epoch
+			json_node['extraData']['finalizedPoint'] = finalization_info.point
+			json_node['extraData']['finalizedHash'] = finalization_info.hash
 
 			if hasattr(api_client, 'get_rest_version'):
 				json_node['apiNodeInfo'] = {}

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -153,12 +153,10 @@ class NodeDownloader:
 		if not self.is_nem:
 			json_node['extraData']['finalizedHeight'] = api_client.get_finalization_info().height
 
-			# add apiNodeInfo if API node roles are included
-			if json_node['roles'] & 2:
-				json_node['apiNodeInfo'] = {}
-				json_node['apiNodeInfo']['restVersion'] = api_client.get_rest_version()
-				json_node['apiNodeInfo']['isHealth'] = api_client.is_node_health()
-				json_node['apiNodeInfo']['isSSL'] = api_client.is_ssl()
+			json_node['apiNodeInfo'] = {}
+			json_node['apiNodeInfo']['restVersion'] = api_client.get_rest_version()
+			json_node['apiNodeInfo']['isSSL'] = api_client.is_ssl()
+			json_node['apiNodeInfo']['isHealth'] = api_client.is_node_health()
 
 	# this function must be called in context of self.lock
 	def _pop_next_api_client(self):


### PR DESCRIPTION
Problem: An AttributeError is raised when the `SymbolPeerClient` object has no attribute `get_rest_version`
Solution: 
- Created `SymbolLightClient` as base class, which can be inherited by `SymbolClient`.
- Added logic to check whether the peer node belongs to the light node.
- Refactor logic to check the host name against `visited_hosts` and `remaining_api_clients` before creating an instance, avoiding any performance issue.