### PR TITLE
[Client]: Query finalization infomation from peer node and attached to the extraData field

### DIFF
--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -127,12 +127,9 @@ class SymbolPeerClient():
 		return self._send_socket_request(5, self._parse_chain_statistics_response)['height']
 
 	def get_finalization_info(self):
-		return FinalizationInfo(
-			self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)['epoch'],
-			self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)['point'],
-			self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)['height'],
-			self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)['hash']
-		)
+		finalization_info = self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)
+
+		return FinalizationInfo(**finalization_info)
 
 	def get_node_info(self):
 		return self._send_socket_request(0x111, self._parse_node_info_response)

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -14,7 +14,7 @@ from zenlog import log
 from .pod import TransactionSnapshot
 from .TimeoutHTTPAdapter import create_http_session
 
-FinalizationInfo = namedtuple('FinalizationInfo', ['epoch', 'point', 'height'])
+FinalizationInfo = namedtuple('FinalizationInfo', ['epoch', 'point', 'height', 'hash'])
 VotingPublicKey = namedtuple('VotingPublicKey', ['start_epoch', 'end_epoch', 'public_key'])
 
 
@@ -75,7 +75,8 @@ class SymbolLightClient:
 		return FinalizationInfo(
 			int(json_finalization_info['finalizationEpoch']),
 			int(json_finalization_info['finalizationPoint']),
-			int(json_finalization_info['height']))
+			int(json_finalization_info['height']),
+			str(json_finalization_info['hash']))
 
 	def get_node_info(self):
 		json_response = self._get_json('node/info')
@@ -126,8 +127,12 @@ class SymbolPeerClient():
 		return self._send_socket_request(5, self._parse_chain_statistics_response)['height']
 
 	def get_finalization_info(self):
-		# epoch and point are zeroed for now
-		return FinalizationInfo(0, 0, self._send_socket_request(5, self._parse_chain_statistics_response)['finalizedHeight'])
+		return FinalizationInfo(
+			self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)['epoch'],
+			self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)['point'],
+			self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)['height'],
+			self._send_socket_request(0x132, self._parse_node_finalization_statistics_response)['hash']
+		)
 
 	def get_node_info(self):
 		return self._send_socket_request(0x111, self._parse_node_info_response)
@@ -198,6 +203,17 @@ class SymbolPeerClient():
 		node_info['friendlyName'] = reader.read_bytes(name_size).decode('utf8')
 
 		return node_info
+
+	@staticmethod
+	def _parse_node_finalization_statistics_response(reader):
+		finalization_statistics = {}
+
+		finalization_statistics['epoch'] = reader.read_int(4)
+		finalization_statistics['point'] = reader.read_int(4)
+		finalization_statistics['height'] = reader.read_int(8)
+		finalization_statistics['hash'] = str(Hash256(reader.read_bytes(32)))
+
+		return finalization_statistics
 
 
 class SymbolClient(SymbolLightClient):

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -151,10 +151,11 @@ class NodeDownloader:
 		json_node['extraData']['height'] = api_client.get_chain_height()
 
 		if not self.is_nem:
-			json_node['extraData']['finalizedHeight'] = api_client.get_finalization_info().height
-			json_node['extraData']['finalizedEpoch'] = api_client.get_finalization_info().epoch
-			json_node['extraData']['finalizedPoint'] = api_client.get_finalization_info().point
-			json_node['extraData']['finalizedHash'] = api_client.get_finalization_info().hash
+			finalization_info = api_client.get_finalization_info()
+			json_node['extraData']['finalizedHeight'] = finalization_info.height
+			json_node['extraData']['finalizedEpoch'] = finalization_info.epoch
+			json_node['extraData']['finalizedPoint'] = finalization_info.point
+			json_node['extraData']['finalizedHash'] = finalization_info.hash
 
 			if hasattr(api_client, 'get_rest_version'):
 				json_node['apiNodeInfo'] = {}

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -152,6 +152,9 @@ class NodeDownloader:
 
 		if not self.is_nem:
 			json_node['extraData']['finalizedHeight'] = api_client.get_finalization_info().height
+			json_node['extraData']['finalizedEpoch'] = api_client.get_finalization_info().epoch
+			json_node['extraData']['finalizedPoint'] = api_client.get_finalization_info().point
+			json_node['extraData']['finalizedHash'] = api_client.get_finalization_info().hash
 
 			if hasattr(api_client, 'get_rest_version'):
 				json_node['apiNodeInfo'] = {}


### PR DESCRIPTION
Problem: finalization epoch, point, and hash are missing.
Solution: Added query finalization statistics from peer node, and attached that information to the `extraData` field

output: 
```json
"extraData": {
      "balance": 0,
      "finalizedEpoch": 2963,
      "finalizedHash": "2414E9245021A45FFE06A12A3BB251860E3588715843E97D3F32459F1E1E038A",
      "finalizedHeight": 4264852,
      "finalizedPoint": 50,
      "height": 4264873
},
"friendlyName": "name",
....
```