### PR TITLE
[miscellaneous/client] fix: update testnet mosaic id

### DIFF
--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -20,7 +20,7 @@ VotingPublicKey = namedtuple('VotingPublicKey', ['start_epoch', 'end_epoch', 'pu
 
 XYM_NETWORK_MOSAIC_IDS_MAP = {
 	0x68: '6BED913FA20223F8',
-	0x98: '3A8416DB2D53B6C8',
+	0x98: '72C0212E67A08BCE',
 	'alias': 'E74B99BA41F4AFEE'
 }
 


### PR DESCRIPTION
Problem: Fetching testnet symbol nodes with balance always 0, because the testnet mosaic ID is outdated.
Solution: Upgrade to the latest testnet mosaic ID.