### PR TITLE
[miscellaneous] fix: handle nem nodes host

### DIFF
--- a/network/nodes.py
+++ b/network/nodes.py
@@ -184,7 +184,10 @@ class NodeDownloader:
 	def _update(self, public_key, json_node, json_peers):
 		self.public_key_to_node_info_map[public_key] = json_node
 		for json_peer in json_peers:
-			host = json_peer.get('host')
+			host = json_peer.get('host')  # handle symbol nodes
+
+			if host is None:
+				host = json_peer.get('endpoint', {}).get('host')  # handle nem nodes
 
 			if host not in self.visited_hosts:
 				if not any(host == api_client.node_host for api_client in self.remaining_api_clients):

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -184,10 +184,7 @@ class NodeDownloader:
 	def _update(self, public_key, json_node, json_peers):
 		self.public_key_to_node_info_map[public_key] = json_node
 		for json_peer in json_peers:
-			host = json_peer.get('host')  # handle symbol nodes
-
-			if host is None:
-				host = json_peer.get('endpoint', {}).get('host')  # handle nem nodes
+			host = json_peer['endpoint']['host'] if self.is_nem else json_peer['host']
 
 			if host not in self.visited_hosts:
 				if not any(host == api_client.node_host for api_client in self.remaining_api_clients):


### PR DESCRIPTION
Problem: `None` host values flood the `remaining_api_clients` list
Solution: Use endpoint.host as fallback for NEM node structure
