### PR TITLE
fix: Catch exceptions when connecting to a non-existent host

### DIFF
--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -150,7 +150,7 @@ class SymbolPeerClient():
 				with self.ssl_context.wrap_socket(sock) as ssock:
 					self._send_simple_request(ssock, packet_type)
 					return parser(self._read_simple_response(ssock))
-		except socket.timeout as ex:
+		except (socket.timeout, socket.gaierror) as ex:
 			raise ConnectionRefusedError from ex
 
 	@staticmethod


### PR DESCRIPTION
## Fix: Handle socket.gaierror to prevent abnormal termination

### Overview
Fixed an issue where `socket.gaierror` was not caught, causing abnormal termination.

### Changes
- Properly catch `socket.gaierror` in `SymbolPeerClient._send_socket_request()`
- Uniformly handle DNS resolution errors as `ConnectionRefusedError`
- Prevent abnormal termination of the application