### PR TITLE
Fix/network access handling

### DIFF
--- a/client/NemClient.py
+++ b/client/NemClient.py
@@ -29,6 +29,7 @@ class AccountInfo:
 class NemClient:
 	def __init__(self, host, port=7890, **kwargs):
 		self.session = create_http_session(**kwargs)
+		self.timeout = kwargs.get('timeout', 5)
 		(self.node_host, self.node_port) = (host, port)
 		self.network = Network.MAINNET
 
@@ -163,11 +164,12 @@ class NemClient:
 
 	def _get_json(self, rest_path):
 		json_http_headers = {'Content-type': 'application/json'}
-		return self.session.get(f'http://{self.node_host}:{self.node_port}/{rest_path}', headers=json_http_headers).json()
+		return self.session.get(f'http://{self.node_host}:{self.node_port}/{rest_path}', headers=json_http_headers, timeout=self.timeout).json()
 
 	def _post_json(self, rest_path, params):
 		json_http_headers = {'Content-type': 'application/json'}
 		return self.session.post(
 			f'http://{self.node_host}:{self.node_port}/{rest_path}',
 			json=params,
-			headers=json_http_headers).json()
+			headers=json_http_headers,
+			timeout=self.timeout).json()

--- a/client/SymbolClient.py
+++ b/client/SymbolClient.py
@@ -112,7 +112,7 @@ class SymbolLightClient:
 
 	def _get_json(self, rest_path):
 		json_http_headers = {'Content-type': 'application/json'}
-		return self.session.get(f'http://{self.node_host}:{self.node_port}/{rest_path}', headers=json_http_headers).json()
+		return self.session.get(f'http://{self.node_host}:{self.node_port}/{rest_path}', headers=json_http_headers, timeout=self.timeout).json()
 
 
 class SymbolPeerClient():

--- a/network/harvester.py
+++ b/network/harvester.py
@@ -4,6 +4,7 @@ import random
 import time
 from threading import Lock, Thread
 
+from requests.exceptions import RequestException
 from zenlog import log
 
 from client.ResourceLoader import create_blockchain_facade, load_resources, locate_blockchain_client_class
@@ -68,41 +69,52 @@ class BatchDownloader:
 
 	def _download_thread(self):
 		while True:
-			with self.lock:
-				height = self.next_height
-				if height > self.max_height:
-					break
+			height = None
+			try:
+				with self.lock:
+					height = self.next_height
+					if height > self.max_height:
+						break
 
-				self.next_height += 1
+					self.next_height += 1
 
-			api_client = random.choice(self.api_clients)
+				api_client = random.choice(self.api_clients)
 
-			num_unique_harvesters = len(self.public_key_to_descriptor_map)
-			log.debug(f'processing block at {height} [{self.max_height - height} remaining, {num_unique_harvesters} unique harvesters]')
-			signer_public_key = api_client.get_harvester_signer_public_key(height)
+				num_unique_harvesters = len(self.public_key_to_descriptor_map)
+				log.debug(f'processing block at {height} [{self.max_height - height} remaining, {num_unique_harvesters} unique harvesters]')
+				signer_public_key = api_client.get_harvester_signer_public_key(height)
 
-			with self.lock:
-				if signer_public_key in self.public_key_to_descriptor_map:
-					continue
+				with self.lock:
+					if signer_public_key in self.public_key_to_descriptor_map:
+						continue
 
-				self.public_key_to_descriptor_map[signer_public_key] = None
+					self.public_key_to_descriptor_map[signer_public_key] = None
 
-			signer_address = self.facade.network.public_key_to_address(signer_public_key)
-			(main_address, main_public_key, balance) = self._get_balance_follow_links(api_client, signer_address)
+				signer_address = self.facade.network.public_key_to_address(signer_public_key)
+				(main_address, main_public_key, balance) = self._get_balance_follow_links(api_client, signer_address)
 
-			log.debug(f'signer {signer_address} is linked to {main_address} with balance {balance}')
+				log.debug(f'signer {signer_address} is linked to {main_address} with balance {balance}')
 
-			descriptor = HarvesterDescriptor()
-			descriptor.signer_public_key = signer_public_key
-			descriptor.signer_address = signer_address
-			descriptor.main_public_key = main_public_key
-			descriptor.main_address = main_address
-			descriptor.balance = balance
+				descriptor = HarvesterDescriptor()
+				descriptor.signer_public_key = signer_public_key
+				descriptor.signer_address = signer_address
+				descriptor.main_public_key = main_public_key
+				descriptor.main_address = main_address
+				descriptor.balance = balance
 
-			with self.lock:
-				self.public_key_to_descriptor_map[signer_public_key] = descriptor
+				with self.lock:
+					self.public_key_to_descriptor_map[signer_public_key] = descriptor
 
-			time.sleep(0.1)
+				time.sleep(0.5)
+
+			except (RequestException, TimeoutError, ConnectionRefusedError) as ex:
+				log.warning(f'failed to process block at height {height}: {ex}')
+				time.sleep(1)
+				continue
+			except Exception as ex:
+				log.error(f'unexpected error processing block at height {height}: {ex}')
+				time.sleep(1)
+				continue
 
 	def _get_balance_follow_links(self, api_client, address):
 		account_info = api_client.get_account_info(address)

--- a/network/harvester.py
+++ b/network/harvester.py
@@ -42,7 +42,14 @@ class BatchDownloader:
 
 	def download_all(self, num_blocks):
 		for node_descriptor in self.nodes:
-			self.api_clients.append(locate_blockchain_client_class(self.resources)(node_descriptor.host, timeout=self.timeout, retry_count=2, retry_post=True))
+			self.api_clients.append(
+				locate_blockchain_client_class(self.resources)(
+					node_descriptor.host,
+					timeout=self.timeout,
+					retry_count=2,
+					retry_post=True
+				)
+			)
 
 		chain_height = random.choice(self.api_clients).get_chain_height()
 

--- a/network/harvester.py
+++ b/network/harvester.py
@@ -40,16 +40,15 @@ class BatchDownloader:
 		self.mosaic_id = mosaic_id
 		self.timeout = timeout
 
+		self.api_client_kwargs = {
+			'timeout': self.timeout,
+			'retry_count': 2,
+			'retry_post': True
+		}
+
 	def download_all(self, num_blocks):
 		for node_descriptor in self.nodes:
-			self.api_clients.append(
-				locate_blockchain_client_class(self.resources)(
-					node_descriptor.host,
-					timeout=self.timeout,
-					retry_count=2,
-					retry_post=True
-				)
-			)
+			self.api_clients.append(locate_blockchain_client_class(self.resources)(node_descriptor.host, **self.api_client_kwargs))
 
 		chain_height = random.choice(self.api_clients).get_chain_height()
 

--- a/network/harvester.py
+++ b/network/harvester.py
@@ -25,7 +25,7 @@ class HarvesterDescriptor:
 class BatchDownloader:
 	# pylint: disable=too-many-instance-attributes
 
-	def __init__(self, resources, thread_count, mosaic_id):
+	def __init__(self, resources, thread_count, mosaic_id, timeout):
 		self.resources = resources
 		self.thread_count = thread_count
 		self.nodes = self.resources.nodes.find_all_not_by_role('seed-only')
@@ -38,10 +38,11 @@ class BatchDownloader:
 		self.public_key_to_descriptor_map = {}
 		self.lock = Lock()
 		self.mosaic_id = mosaic_id
+		self.timeout = timeout
 
 	def download_all(self, num_blocks):
 		for node_descriptor in self.nodes:
-			self.api_clients.append(locate_blockchain_client_class(self.resources)(node_descriptor.host, timeout=60, retry_post=True))
+			self.api_clients.append(locate_blockchain_client_class(self.resources)(node_descriptor.host, timeout=self.timeout, retry_count=2, retry_post=True))
 
 		chain_height = random.choice(self.api_clients).get_chain_height()
 
@@ -64,7 +65,6 @@ class BatchDownloader:
 			with self.lock:
 				height = self.next_height
 				if height > self.max_height:
-					time.sleep(2)
 					break
 
 				self.next_height += 1
@@ -96,6 +96,8 @@ class BatchDownloader:
 			with self.lock:
 				self.public_key_to_descriptor_map[signer_public_key] = descriptor
 
+			time.sleep(0.1)
+
 	def _get_balance_follow_links(self, api_client, address):
 		account_info = api_client.get_account_info(address)
 
@@ -109,10 +111,11 @@ class BatchDownloader:
 
 
 class HarvesterDownloader:
-	def __init__(self, resources, num_blocks, nodes_input_filepath):
+	def __init__(self, resources, num_blocks, nodes_input_filepath, timeout):
 		self.resources = resources
 		self.num_blocks = num_blocks
 		self.nodes_input_filepath = nodes_input_filepath
+		self.timeout = timeout
 
 		self.peers_map = {}
 
@@ -121,7 +124,7 @@ class HarvesterDownloader:
 
 		log.info(f'downloading harvester activity to {output_filepath} for last {self.num_blocks} blocks')
 
-		batch_downloader = BatchDownloader(self.resources, thread_count, mosaic_id)
+		batch_downloader = BatchDownloader(self.resources, thread_count, mosaic_id, self.timeout)
 		batch_downloader.download_all(self.num_blocks)
 
 		with open(output_filepath, 'wt', encoding='utf8') as outfile:
@@ -130,6 +133,9 @@ class HarvesterDownloader:
 			csv_writer.writeheader()
 
 			for harvester_descriptor in batch_downloader.public_key_to_descriptor_map.values():
+				if harvester_descriptor is None:
+					continue
+
 				node_descriptor = self.peers_map.get(harvester_descriptor.main_public_key, EMPTY_NODE_DESCRIPTOR)
 
 				csv_writer.writerow({
@@ -159,11 +165,12 @@ def main():
 	parser.add_argument('--output', help='output file', required=True)
 	parser.add_argument('--thread-count', help='number of threads', type=int, default=16)
 	parser.add_argument('--mosaic-id', help='mosaic id', default=MAINNET_XYM_MOSAIC_ID)
+	parser.add_argument('--timeout', help='peer timeout', type=int, default=20)
 	args = parser.parse_args()
 
 	resources = load_resources(args.resources)
 	blocks_per_day = 60 if 'nem' == resources.friendly_name else 120
-	downloader = HarvesterDownloader(resources, int(args.days * 24 * blocks_per_day), args.nodes)
+	downloader = HarvesterDownloader(resources, int(args.days * 24 * blocks_per_day), args.nodes, args.timeout)
 	downloader.download(args.thread_count, args.output, args.mosaic_id)
 
 

--- a/network/harvester.py
+++ b/network/harvester.py
@@ -111,10 +111,6 @@ class BatchDownloader:
 				log.warning(f'failed to process block at height {height}: {ex}')
 				time.sleep(1)
 				continue
-			except Exception as ex:
-				log.error(f'unexpected error processing block at height {height}: {ex}')
-				time.sleep(1)
-				continue
 
 	def _get_balance_follow_links(self, api_client, address):
 		account_info = api_client.get_account_info(address)

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -34,6 +34,12 @@ class NodeDownloader:
 		self.busy_thread_count = 0
 		self.lock = Lock()
 
+		self.api_client_kwargs = {
+			'timeout': self.timeout,
+			'retry_count': 2,
+			'retry_post': False
+		}
+
 	@property
 	def is_nem(self):
 		return 'nem' == self.resources.friendly_name
@@ -41,10 +47,10 @@ class NodeDownloader:
 	def discover(self):
 		log.info('seeding crawler with known hosts')
 		self.remaining_api_clients = [
-			self.api_client_class(node_descriptor.host) for node_descriptor in self.resources.nodes.find_all_by_role(None)
+			self.api_client_class(node_descriptor.host, **self.api_client_kwargs) for node_descriptor in self.resources.nodes.find_all_by_role(None)
 		]
 		self.strong_api_clients = [
-			self.api_client_class(node_descriptor.host) for node_descriptor in self.resources.nodes.find_all_not_by_role('seed-only')
+			self.api_client_class(node_descriptor.host, **self.api_client_kwargs) for node_descriptor in self.resources.nodes.find_all_not_by_role('seed-only')
 		]
 
 		log.info(f'starting {self.thread_count} crawler threads')
@@ -191,9 +197,8 @@ class NodeDownloader:
 				if not any(host == api_client.node_host for api_client in self.remaining_api_clients):
 					peer_api_client = self.api_client_class.from_node_info_dict(
 						json_peer,
-						retry_count=2,
-						timeout=self.timeout,
-						certificate_directory=self.certificate_directory)
+						certificate_directory=self.certificate_directory,
+						**self.api_client_kwargs)
 
 					self.remaining_api_clients.append(peer_api_client)
 

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -66,9 +66,10 @@ class NodeDownloader:
 
 			with self.lock:
 				api_client = self._pop_next_api_client()
-				if not api_client:
-					time.sleep(2)
-					continue
+
+			if not api_client:
+				time.sleep(2)
+				continue
 
 			log.debug(
 				f'processing {api_client.node_host} [{len(self.public_key_to_node_info_map)} discovered,'

--- a/network/nodes.py
+++ b/network/nodes.py
@@ -47,10 +47,12 @@ class NodeDownloader:
 	def discover(self):
 		log.info('seeding crawler with known hosts')
 		self.remaining_api_clients = [
-			self.api_client_class(node_descriptor.host, **self.api_client_kwargs) for node_descriptor in self.resources.nodes.find_all_by_role(None)
+			self.api_client_class(node_descriptor.host, **self.api_client_kwargs)
+			for node_descriptor in self.resources.nodes.find_all_by_role(None)
 		]
 		self.strong_api_clients = [
-			self.api_client_class(node_descriptor.host, **self.api_client_kwargs) for node_descriptor in self.resources.nodes.find_all_not_by_role('seed-only')
+			self.api_client_class(node_descriptor.host, **self.api_client_kwargs)
+			for node_descriptor in self.resources.nodes.find_all_not_by_role('seed-only')
 		]
 
 		log.info(f'starting {self.thread_count} crawler threads')

--- a/network/richlist_symbol.py
+++ b/network/richlist_symbol.py
@@ -18,14 +18,13 @@ class RichListDownloader:
 		self.min_balance = min_balance
 		self.mosaic_id = mosaic_id
 		self.nodes_input_filepath = nodes_input_filepath
-		self.timeout = timeout
 
-		self.api_client_kwargs = {
-			'timeout': self.timeout,
+		api_client_kwargs = {
+			'timeout': timeout,
 			'retry_count': 2,
 			'retry_post': False
 		}
-		self.api_client = create_blockchain_api_client(self.resources, **self.api_client_kwargs)
+		self.api_client = create_blockchain_api_client(self.resources, **api_client_kwargs)
 
 		self.finalization_epoch = 0
 		self.voters_map = {}

--- a/network/richlist_symbol.py
+++ b/network/richlist_symbol.py
@@ -18,7 +18,14 @@ class RichListDownloader:
 		self.min_balance = min_balance
 		self.mosaic_id = mosaic_id
 		self.nodes_input_filepath = nodes_input_filepath
-		self.api_client = create_blockchain_api_client(self.resources, None, timeout=timeout, retry_count=2)
+		self.timeout = timeout
+
+		self.api_client_kwargs = {
+			'timeout': self.timeout,
+			'retry_count': 2,
+			'retry_post': False
+		}
+		self.api_client = create_blockchain_api_client(self.resources, **self.api_client_kwargs)
 
 		self.finalization_epoch = 0
 		self.voters_map = {}

--- a/network/richlist_symbol.py
+++ b/network/richlist_symbol.py
@@ -12,6 +12,8 @@ MAINNET_XYM_MOSAIC_ID = '6BED913FA20223F8'
 
 class RichListDownloader:
 	def __init__(self, resources, min_balance, mosaic_id, nodes_input_filepath, timeout):
+		# pylint: disable=too-many-arguments, too-many-positional-arguments
+
 		self.resources = resources
 		self.min_balance = min_balance
 		self.mosaic_id = mosaic_id

--- a/network/richlist_symbol.py
+++ b/network/richlist_symbol.py
@@ -11,12 +11,12 @@ MAINNET_XYM_MOSAIC_ID = '6BED913FA20223F8'
 
 
 class RichListDownloader:
-	def __init__(self, resources, min_balance, mosaic_id, nodes_input_filepath):
+	def __init__(self, resources, min_balance, mosaic_id, nodes_input_filepath, timeout):
 		self.resources = resources
 		self.min_balance = min_balance
 		self.mosaic_id = mosaic_id
 		self.nodes_input_filepath = nodes_input_filepath
-		self.api_client = create_blockchain_api_client(self.resources)
+		self.api_client = create_blockchain_api_client(self.resources, None, timeout=timeout, retry_count=2)
 
 		self.finalization_epoch = 0
 		self.voters_map = {}
@@ -104,10 +104,11 @@ def main():
 	parser.add_argument('--mosaic-id', help='mosaic id', default=MAINNET_XYM_MOSAIC_ID)
 	parser.add_argument('--nodes', help='(optional) nodes json file')
 	parser.add_argument('--output', help='output file', required=True)
+	parser.add_argument('--timeout', help='peer timeout', type=int, default=20)
 	args = parser.parse_args()
 
 	resources = load_resources(args.resources)
-	downloader = RichListDownloader(resources, args.min_balance, args.mosaic_id, args.nodes)
+	downloader = RichListDownloader(resources, args.min_balance, args.mosaic_id, args.nodes, args.timeout)
 	downloader.download(args.output)
 
 


### PR DESCRIPTION
## Network Access Processing Fixes

### Changes
- Added timeout and retry parameters to API client connections
- Improved network resilience for harvester and richlist downloaders
- Removed unnecessary locks to enhance performance

### Details
- `harvester.py`: Added `timeout`, `retry_count=2`, `retry_post=True` during API client initialization
- `richlist_symbol.py`: Added `timeout`, `retry_count=2` to the blockchain API client
- Optimized lock contention in parallel processing

### Effects
- Improved stability of network data collection processing
- Performance gains through reduced thread contention

### Usage
Add `--timeout` as an argument.

(Excerpt from pull.sh)
```
python3 -m network.richlist_symbol \
	--resources ./networks/symbol.yaml \
	--min-balance 250000 \
	--nodes "$1/symbol_nodes.json" \
	--output "$1/symbol_richlist.csv" \
	--timeout "$2"
```

```
python3 -m network.harvester \
	--resources ./networks/symbol.yaml \
	--thread-count 64 \
	--nodes "$1/symbol_nodes.json" \
	--days 3.5 \
	--output "$1/symbol_harvesters.csv" \
	--timeout "$2"
```